### PR TITLE
Fix IndexError: list index out of range

### DIFF
--- a/bin/CoV_stat.py
+++ b/bin/CoV_stat.py
@@ -70,7 +70,7 @@ def stat_fq(fqstat,outdict,fqtype):
 				elif fqtype == 'SE':
 					G_number = int(info[4])
 			if 'Number of filtered reads' in line:
-				filter_rate = line.split('(')[2].split(')')[0].strip()
+				filter_rate = line.split('(')[1].split(')')[0].strip()
 				outdict['filter_rate'] = filter_rate
 				outdict['clean_rate'] = str('%.2f'%(100 - float(filter_rate.strip('%'))))+'%'
 			if 'Q20 number' in line:


### PR DESCRIPTION
Fix following error:
```
Traceback (most recent call last):
  File "/data/pipeline/SARS-CoV-2_Multi-PCR_v1.1/bin/CoV_stat.py", line 224, in <module>
    main()
  File "/data/pipeline/SARS-CoV-2_Multi-PCR_v1.1/bin/CoV_stat.py", line 184, in main
    stat_sample(resultdir,sample,out_dict,lambda_dict,GAPDH_dict)
  File "/data/pipeline/SARS-CoV-2_Multi-PCR_v1.1/bin/CoV_stat.py", line 166, in stat_sample
    stat_fq(file_fq_stat,out_dict,fqtype)
  File "/data/pipeline/SARS-CoV-2_Multi-PCR_v1.1/bin/CoV_stat.py", line 73, in stat_fq
    filter_rate = line.split('(')[2].split(')')[0].strip()
IndexError: list index out of range
```